### PR TITLE
Adding interceptors to axios instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@ var ResponseMiddleware = require('./lib/ResponseMiddleware');
 
 var cassettes = {}
 
-function mountCassette(cassettePath) {
-  var axios = require('axios');
+function mountCassette(cassettePath, options = {}) {
+  var defaults = {
+    instance: require('axios')
+  }
+  options = Object.assign(defaults, options);
+  var axios = options.instance;
 
   var responseInterceptor = axios.interceptors.response.use(
     ResponseMiddleware.success(cassettePath),

--- a/test/axios_instance_test.js
+++ b/test/axios_instance_test.js
@@ -1,0 +1,161 @@
+var fs = require('fs')
+var rimraf = require('rimraf')
+var assert = require('assert')
+var VCR = require('../index')
+var _ = require('lodash')
+
+function clearFixtures() {
+  rimraf.sync('./test/fixtures')
+}
+
+function fileExists(path) {
+  try {
+    return fs.statSync(path).isFile()
+  } catch(e) {
+    return false
+  }
+}
+
+function getFixture(cassettePath, config) {
+  var loadAt = require('../lib/jsonDb').loadAt
+  var digest = require('../lib/digest')
+  var key = digest(config)
+
+  return loadAt(cassettePath, key)
+}
+
+describe.only('Axios Instance VCR', function() {
+  this.timeout(10000)
+  var posts = 'http://jsonplaceholder.typicode.com/posts/1'
+  var axios = require('axios')
+  var instance = axios.create({
+    headers: {'X-axios-vcr': 'I am an instace'}
+  })
+
+  describe('recording', function() {
+    beforeEach(clearFixtures)
+    afterEach(clearFixtures)
+
+    it('generates stubs for requests', function(done) {
+      var path = './test/fixtures/posts.json'
+      VCR.mountCassette(path, { instance: instance })
+
+      instance.get(posts).then(function(response) {
+        getFixture(path, response.config).then(function(fixture) {
+          assert.deepEqual(fixture.originalResponseData.data, response.data)
+          done()
+          VCR.ejectCassette(path)
+        })
+      })
+    })
+
+    it('works with nested folders', function(done) {
+      var cassettePath = './test/fixtures/nested/posts.json'
+      VCR.mountCassette(cassettePath, { instance: instance })
+
+      instance.get(posts).then(function(response) {
+        getFixture(cassettePath, response.config).then(function(fixture) {
+          assert.deepEqual(fixture.originalResponseData.data, response.data)
+          done()
+
+          VCR.ejectCassette(cassettePath)
+        })
+      }).catch(function(err) { console.log(err) })
+    })
+
+    it('stores headers and status', function(done) {
+      var cassettePath = './test/fixtures/posts.json'
+      VCR.mountCassette(cassettePath, { instance: instance })
+
+      instance.get(posts).then(function(response) {
+        getFixture(cassettePath, response.config).then(function(fixture) {
+          assert.deepEqual(fixture.originalResponseData.headers, response.headers)
+          assert.equal(fixture.originalResponseData.status, response.status)
+          assert.equal(fixture.originalResponseData.statusText, response.statusText)
+          done()
+
+          VCR.ejectCassette(cassettePath)
+        })
+      })
+    })
+  })
+
+  describe('replaying', function() {
+    /*
+      This is a tricky test.
+      I'm not aware of any way to check that a network request has been made.
+      So instead we hit an unexisting URL that is backed by a cassette. We can now
+      check that the response is the same as the cassette file.
+    */
+    it.skip('skips remote calls', function(done) {
+      var path = './test/static_fixtures/posts.json'
+      assert(fileExists(path))
+
+      var url = 'http://something.com/unexisting'
+      VCR.mountCassette(path, { instance: instance })
+
+      instance.get(url).then(function(res) {
+        getFixture(path, res.config).then(function(fixture) {
+          assert.deepEqual(fixture.originalResponseData, _.omit(res, 'fixture'))
+          done()
+
+          VCR.ejectCassette(path)
+        }).catch(done)
+      }).catch(done)
+    })
+
+    it('makes remote call when a cassette is not available', function(done) {
+      var path = './test/static_fixtures/no_posts.json'
+
+      try {
+        fs.unlinkSync(path)
+      } catch(e) {}
+
+      assert(!fileExists(path))
+      VCR.mountCassette(path, { instance: instance })
+
+      instance.get(posts).then(function(response) {
+        assert.equal(200, response.status)
+        fs.unlinkSync(path)
+        done()
+
+        VCR.ejectCassette(path)
+      })
+    })
+  })
+
+  describe('Multiple Requests', function() {
+    this.timeout(15000)
+
+    beforeEach(clearFixtures)
+    afterEach(clearFixtures)
+
+    var usersUrl = 'http://jsonplaceholder.typicode.com/users'
+    var todosUrl = 'http://jsonplaceholder.typicode.com/todos'
+
+    it('stores multiple requests in the same cassette', function(done) {
+      var path = './test/fixtures/multiple.json'
+
+      VCR.mountCassette(path, { instance: instance })
+
+      var usersPromise = instance.get(usersUrl)
+      var todosPromise = instance.get(todosUrl)
+
+      Promise.all([usersPromise, todosPromise]).then(function(responses) {
+        var usersResponse = responses[0]
+        var todosResponse = responses[1]
+
+        var usersResponsePromise = getFixture(path, usersResponse.config)
+        var todosResponsePromise = getFixture(path, todosResponse.config)
+
+        Promise.all([usersResponsePromise, todosResponsePromise]).then(function(fixtures) {
+          assert.deepEqual(fixtures[0].originalResponseData.data, usersResponse.data)
+          assert.deepEqual(fixtures[1].originalResponseData.data, todosResponse.data)
+          done()
+
+          VCR.ejectCassette(path)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This is WIP. Creating PR to get some feedback.

I am interested in using `axios-vcr` in my tests, but I use `axios` instances. I am proposing adding a second parameter to `VCR.mountCassette` with options, being the first one in this case `instance`

I am defaulting to `require('axios')` for backwards compatibility. As far as I can see, the change do not break current tests, but I have duplicated the main test file to test against my instance and found a few issues:

* The interceptor is not skipping calls when file exists
* That test is skipped at the moment because enabling it breaks things in a weird way. May be you know why.
* How could we share the tests against both `axios` and and instance? I don't like the duplication that testing both options would bring. The current new test file is just a work in progress and I hope we can find a better way
* I would also consider a global `VCR` configuration to avoid adding the options on every test.

I hope you can have a look at this in case I am missing something, specially with the failing (skipped) case.

EDIT: some typos