### PR TITLE
update to support axios v0.18.0 and solve race condition

### DIFF
--- a/lib/RequestMiddleware.js
+++ b/lib/RequestMiddleware.js
@@ -25,9 +25,9 @@ exports.success = function (cassettePath) {
     injectVCRHeader(axiosConfig)
 
     return loadFixture(cassettePath, axiosConfig).then(function(cassette) {
-      axiosConfig.adapter = function(resolve, _reject, _cfg) {
+      axiosConfig.adapter = function(_config) {
         cassette.originalResponseData.fixture = true
-        return resolve(cassette.originalResponseData)
+        return Promise.resolve(cassette.originalResponseData)
       }
       return axiosConfig
     }).catch(function(err) {

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -1,18 +1,48 @@
 var md5 = require('md5')
 var _ = require('lodash')
 
-function key(axiosConfig) {
-  //Content-Length is calculated automatically by Axios before sending a request
-  //We don't want to include it here because it could be changed by axios
+var utils = require('axios/lib/utils')
+var transformData = require('axios/lib/core/transformData')
+var isCancel = require('axios/lib/cancel/isCancel')
+var defaults = require('axios/lib/defaults')
+var isAbsoluteURL = require('axios/lib/helpers/isAbsoluteURL')
+var combineURLs = require('axios/lib/helpers/combineURLs')
 
+function key (axiosConfig) {
+  const config = _.cloneDeep(axiosConfig)
+
+  if (config.baseURL && !isAbsoluteURL(config.url)) {
+    config.url = combineURLs(config.baseURL, config.url)
+  }
+
+  config.headers = config.headers || {}
+
+  config.data = transformData(
+    config.data,
+    config.headers,
+    config.transformRequest
+  )
+
+  config.headers = utils.merge(
+    config.headers.common || {},
+    config.headers[config.method] || {},
+    config.headers || {}
+  )
+
+  utils.forEach(
+    ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'],
+    function cleanHeaderConfig (method) {
+      delete config.headers[method]
+    }
+  )
 
   var baseConfig = {
-    url: axiosConfig.url,
-    method: axiosConfig.method,
-    data: axiosConfig.data,
-    headers: _.omit(axiosConfig.headers, [
-      'Content-Length', 'content-length'
-    ])
+    url: config.url,
+    method: config.method,
+    data: config.data,
+    //Content-Length is calculated automatically by Axios before sending a request
+    //We don't want to include it here because it could be changed by axios
+    headers: _.omit(config.headers, ['Content-Length', 'content-length']),
   }
 
   return md5(JSON.stringify(baseConfig))

--- a/lib/jsonDb.js
+++ b/lib/jsonDb.js
@@ -3,6 +3,32 @@ var _ = require('lodash')
 var mkdirp = require('mkdirp')
 var getDirName = require('path').dirname
 
+var writing = false
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function write(filePath, jsonPath, value) {
+  return fs
+    .readJson(filePath)
+    .then(function(json) {
+      _.set(json, jsonPath, value)
+      return fs.writeJson(filePath, json)
+    })
+    .catch(function(error) {
+      var json = {}
+      _.set(json, jsonPath, value)
+      return fs.writeJson(filePath, json)
+    })
+    .then(function() {
+      writing = false
+    })
+    .catch(function() {
+      writing = false
+    })
+}
+
 function loadAt(filePath, jsonPath) {
   return fs.readJson(filePath).then(function(json) {
     if (_.isUndefined(jsonPath))
@@ -17,16 +43,13 @@ function loadAt(filePath, jsonPath) {
 }
 
 function writeAt(filePath, jsonPath, value) {
-  mkdirp.sync(getDirName(filePath))
-
-  return fs.readJson(filePath).then(function(json) {
-    _.set(json, jsonPath, value)
-    return fs.writeJson(filePath, json)
-  }).catch(function(error) {
-    var json = {}
-    _.set(json, jsonPath, value)
-    return fs.writeJson(filePath, json)
-  })
+  if (!writing) {
+    writing = true
+    mkdirp.sync(getDirName(filePath))
+    return write(filePath, jsonPath, value)
+  } else {
+    return sleep(2000).then(() => writeAt(filePath, jsonPath, value))
+  }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Netto Farah",
   "license": "MIT",
   "devDependencies": {
-    "axios": "^0.11.1",
+    "axios": "^0.18.0",
     "mocha": "^2.5.3",
     "rimraf": "^2.5.2"
   },

--- a/test/axios_vcr_test.js
+++ b/test/axios_vcr_test.js
@@ -38,12 +38,12 @@ describe('Axios VCR', function() {
       VCR.mountCassette(path)
 
       axios.get(posts).then(function(response) {
-        getFixture(path, response.config).then(function(fixture) {
+        return getFixture(path, response.config).then(function(fixture) {
           assert.deepEqual(fixture.originalResponseData.data, response.data)
           done()
           VCR.ejectCassette(path)
         })
-      })
+      }).catch(function(err) { console.log(err); done() })
     })
 
     it('works with nested folders', function(done) {
@@ -51,13 +51,13 @@ describe('Axios VCR', function() {
       VCR.mountCassette(cassettePath)
 
       axios.get(posts).then(function(response) {
-        getFixture(cassettePath, response.config).then(function(fixture) {
+        return getFixture(cassettePath, response.config).then(function(fixture) {
           assert.deepEqual(fixture.originalResponseData.data, response.data)
           done()
 
           VCR.ejectCassette(cassettePath)
         })
-      }).catch(function(err) { console.log(err) })
+      }).catch(function(err) { console.log(err); done() })
     })
 
     it('stores headers and status', function(done) {
@@ -65,7 +65,7 @@ describe('Axios VCR', function() {
       VCR.mountCassette(cassettePath)
 
       axios.get(posts).then(function(response) {
-        getFixture(cassettePath, response.config).then(function(fixture) {
+        return getFixture(cassettePath, response.config).then(function(fixture) {
           assert.deepEqual(fixture.originalResponseData.headers, response.headers)
           assert.equal(fixture.originalResponseData.status, response.status)
           assert.equal(fixture.originalResponseData.statusText, response.statusText)
@@ -73,7 +73,7 @@ describe('Axios VCR', function() {
 
           VCR.ejectCassette(cassettePath)
         })
-      })
+      }).catch(function(err) { console.log(err); done() })
     })
   })
 
@@ -92,7 +92,7 @@ describe('Axios VCR', function() {
       VCR.mountCassette(path)
 
       axios.get(url).then(function(res) {
-        getFixture(path, res.config).then(function(fixture) {
+        return getFixture(path, res.config).then(function(fixture) {
           assert.deepEqual(fixture.originalResponseData, _.omit(res, 'fixture'))
           done()
 
@@ -117,7 +117,7 @@ describe('Axios VCR', function() {
         done()
 
         VCR.ejectCassette(path)
-      })
+      }).catch(err => { console.log(err); done() })
     })
   })
 
@@ -145,14 +145,14 @@ describe('Axios VCR', function() {
         var usersResponsePromise = getFixture(path, usersResponse.config)
         var todosResponsePromise = getFixture(path, todosResponse.config)
 
-        Promise.all([usersResponsePromise, todosResponsePromise]).then(function(fixtures) {
+        return Promise.all([usersResponsePromise, todosResponsePromise]).then(function(fixtures) {
           assert.deepEqual(fixtures[0].originalResponseData.data, usersResponse.data)
           assert.deepEqual(fixtures[1].originalResponseData.data, todosResponse.data)
           done()
 
           VCR.ejectCassette(path)
         })
-      })
+      }).catch(err => { console.log(err); done() })
     })
   })
 })

--- a/test/digest_test.js
+++ b/test/digest_test.js
@@ -16,7 +16,7 @@ describe('Digest', function() {
       method: 'get',
       data: {},
       headers: {
-        'user-agent': 'test'
+        'user-agent': 'test',
       },
       extraProperty: 'bla',
       somethingElse: 'irrelevant'


### PR DESCRIPTION
The most important change in this commit is the digest function. In version 0.13.0 there was a
[commit in axios](https://github.com/axios/axios/commit/e833a2f7e4a5ec32516e3f17763374c0377a4323) moving the request transformers to after the request interceptors. This means that the request interceptors will see a different configuration from the response interceptor, so the output of the digest function will be different in these interceptors, breaking axios-vcr functionality. To solve this we can simply apply the same request transformers to the configuration in the request interceptor.