### PR TITLE
Added support to multiple Axios instances. Added params to md5 digest. Recording and Replaying 404 requests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function mountCassette(cassettePath, client) {
 
   let responseInterceptor = axios.interceptors.response.use(
     ResponseMiddleware.success(cassettePath),
-    ResponseMiddleware.failure
+    ResponseMiddleware.failure(cassettePath)
   );
 
   let requestInterceptor = axios.interceptors.request.use(

--- a/index.js
+++ b/index.js
@@ -3,8 +3,13 @@ const ResponseMiddleware = require('./lib/ResponseMiddleware');
 
 const cassettes = {}
 
-function mountCassette(cassettePath) {
-  const axios = require('axios');
+function mountCassette(cassettePath, client) {
+  let axios = null;
+  if ( client == null ) {
+    axios = require('axios');
+  } else {
+    axios = client;
+  }
 
   let responseInterceptor = axios.interceptors.response.use(
     ResponseMiddleware.success(cassettePath),

--- a/lib/RequestMiddleware.js
+++ b/lib/RequestMiddleware.js
@@ -1,5 +1,6 @@
 const digest = require('./digest')
 const jsonDB = require('./jsonDb')
+const createError = require('axios/lib/core/createError');
 
 function loadFixture(cassettePath, axiosConfig) {
   let requestKey = digest(axiosConfig)
@@ -26,9 +27,19 @@ exports.success = function (cassettePath) {
 
     return loadFixture(cassettePath, axiosConfig).then(function(cassette) {
       axiosConfig.adapter = function() {
-        return new Promise(function(resolve) {
+        return new Promise(function(resolve, reject) {
           cassette.originalResponseData.fixture = true
-          return resolve(cassette.originalResponseData)
+          if ( 404 == cassette.originalResponseData.status ) {
+            return reject(createError(
+              'Request failed with status code ' + cassette.originalResponseData.status,
+              cassette.originalResponseData.config,
+              null,
+              cassette.originalResponseData.request,
+              cassette.originalResponseData
+            ))
+          } else {
+            return resolve(cassette.originalResponseData)
+          }
         });
       }
       return axiosConfig

--- a/lib/RequestMiddleware.js
+++ b/lib/RequestMiddleware.js
@@ -28,9 +28,8 @@ exports.success = function (cassettePath) {
     return loadFixture(cassettePath, axiosConfig).then(function(cassette) {
       axiosConfig.adapter = function() {
         return new Promise(function(resolve, reject) {
-	  cassette.originalResponseData = cassette.originalResponseData||{}
           cassette.originalResponseData.fixture = true
-          if ( cassette.originalReponseData && 404 == cassette.originalResponseData.status ) {
+          if ( cassette.originalResponseData && 404 == cassette.originalResponseData.status ) {
             return reject(createError(
               'Request failed with status code ' + cassette.originalResponseData.status,
               cassette.originalResponseData.config,

--- a/lib/RequestMiddleware.js
+++ b/lib/RequestMiddleware.js
@@ -29,7 +29,7 @@ exports.success = function (cassettePath) {
       axiosConfig.adapter = function() {
         return new Promise(function(resolve, reject) {
           cassette.originalResponseData.fixture = true
-          if ( 404 == cassette.originalResponseData.status ) {
+          if ( cassette.originalReponseData && 404 == cassette.originalResponseData.status ) {
             return reject(createError(
               'Request failed with status code ' + cassette.originalResponseData.status,
               cassette.originalResponseData.config,

--- a/lib/RequestMiddleware.js
+++ b/lib/RequestMiddleware.js
@@ -28,6 +28,7 @@ exports.success = function (cassettePath) {
     return loadFixture(cassettePath, axiosConfig).then(function(cassette) {
       axiosConfig.adapter = function() {
         return new Promise(function(resolve, reject) {
+	  cassette.originalResponseData = cassette.originalResponseData||{}
           cassette.originalResponseData.fixture = true
           if ( cassette.originalReponseData && 404 == cassette.originalResponseData.status ) {
             return reject(createError(

--- a/lib/ResponseMiddleware.js
+++ b/lib/ResponseMiddleware.js
@@ -42,7 +42,7 @@ exports.success = function (cassettePath) {
 
 exports.failure = function(cassettePath) {
   return function(error) {
-    if ( "404" == error.response.status ) {
+    if ( error.response && "404" == error.response.status ) {
       storeFixture(cassettePath, error.response)
     }
     return Promise.reject(error)

--- a/lib/ResponseMiddleware.js
+++ b/lib/ResponseMiddleware.js
@@ -26,6 +26,7 @@ function serialize(response) {
 function storeFixture(cassettePath, response) {
   let requestKey = digest(response.config)
   let fixture = serialize(response)
+
   return jsonDB.writeAt(cassettePath, requestKey, fixture)
 }
 
@@ -42,8 +43,10 @@ exports.success = function (cassettePath) {
 
 exports.failure = function(cassettePath) {
   return function(error) {
-    if ( error.response && "404" == error.response.status ) {
-      storeFixture(cassettePath, error.response)
+    if ( error && error.response && "404" == error.response.status ) {
+      return storeFixture(cassettePath, error.response).then(function(){
+        return Promise.reject(error)
+      })
     }
     return Promise.reject(error)
   }

--- a/lib/ResponseMiddleware.js
+++ b/lib/ResponseMiddleware.js
@@ -40,6 +40,11 @@ exports.success = function (cassettePath) {
   }
 }
 
-exports.failure = function(error) {
-  return Promise.reject(error)
+exports.failure = function(cassettePath) {
+  return function(error) {
+    if ( "404" == error.response.status ) {
+      storeFixture(cassettePath, error.response)
+    }
+    return Promise.reject(error)
+  }
 }

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -9,6 +9,7 @@ function key(axiosConfig) {
   let method = axiosConfig.method
   let data = axiosConfig.data
   let headers = axiosConfig.headers
+  let params = axiosConfig.params
 
   if (_.isString(data)) {
     data = JSON.parse(data)
@@ -27,8 +28,7 @@ function key(axiosConfig) {
   headers = _.omit(headers, [
     'Content-Length', 'content-length'
   ])
-
-  return md5(JSON.stringify({ url, method, data, headers }))
+  return md5(JSON.stringify({ url, method, data, headers, params }))
 }
 
 module.exports = key

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -28,7 +28,6 @@ function key(axiosConfig) {
   headers = _.omit(headers, [
     'Content-Length', 'content-length'
   ])
-
   return md5(JSON.stringify({ url, method, data, headers, params }))
 }
 

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -9,6 +9,7 @@ function key(axiosConfig) {
   let method = axiosConfig.method
   let data = axiosConfig.data
   let headers = axiosConfig.headers
+  let params = axiosConfig.params
 
   if (_.isString(data)) {
     data = JSON.parse(data)
@@ -28,7 +29,7 @@ function key(axiosConfig) {
     'Content-Length', 'content-length'
   ])
 
-  return md5(JSON.stringify({ url, method, data, headers }))
+  return md5(JSON.stringify({ url, method, data, headers, params }))
 }
 
 module.exports = key

--- a/lib/jsonDb.js
+++ b/lib/jsonDb.js
@@ -1,4 +1,4 @@
-const fs = require('fs-promise')
+const fs = require('fs-extra')
 const _ = require('lodash')
 const mkdirp = require('mkdirp')
 const getDirName = require('path').dirname
@@ -13,7 +13,7 @@ function loadAt(filePath, jsonPath) {
       return value
     else
       throw "Invalid JSON Path"
-  })
+  }).catch(err => console.log(err))
 }
 
 function writeAt(filePath, jsonPath, value) {

--- a/lib/jsonDb.js
+++ b/lib/jsonDb.js
@@ -11,14 +11,14 @@ function loadAt(filePath, jsonPath) {
     let value = _.get(json, jsonPath)
     if (!_.isUndefined(value))
       return value
-    else
+    else {
       throw "Invalid JSON Path"
-  }).catch(err => console.log(err))
+    }
+  })
 }
 
 function writeAt(filePath, jsonPath, value) {
   mkdirp.sync(getDirName(filePath))
-
   return fs.readJson(filePath).then(function(json) {
     _.set(json, jsonPath, value)
     return fs.writeJson(filePath, json)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "fs-promise": "^0.5.0",
+    "fs-extra": "^3.0.0",
     "lodash": "^4.13.1",
     "md5": "^2.1.0",
     "mkdirp": "^0.5.1"


### PR DESCRIPTION
* Added support to multiple Axios instances.
It's now possible to pass the Axios instance as an argument when mounting cassettes.

* Added params to md5 digest.
Request `params` is now part of the md5 digest.

* Recording and Replaying 404 responses.
Catch 404 responses and throw them when replaying.